### PR TITLE
Add model_ai addon for ChatGPT integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # odoo_AI
+
+Custom module collection for Odoo 14.0.
+
+## model_ai
+
+The `model_ai` addon provides a simple interface to send prompts to OpenAI's
+ChatGPT API directly from Odoo and store the responses.
+
+### Configuration
+
+1. Install the module via the Apps menu.
+2. Navigate to *Settings → Technical → Parameters → System Parameters*.
+3. Create or update the parameter `model_ai.openai_api_key` with your OpenAI
+   API key.
+
+### Usage
+
+Open the **Model AI → Prompts** menu, write a new prompt, and click **Send
+Prompt** to fetch the response from ChatGPT.

--- a/model_ai/__init__.py
+++ b/model_ai/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/model_ai/__manifest__.py
+++ b/model_ai/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Model AI',
+    'version': '14.0.1.0.0',
+    'summary': 'Integrate ChatGPT prompts inside Odoo',
+    'description': 'Send prompts to OpenAI\'s ChatGPT API and capture the responses.',
+    'category': 'Productivity',
+    'author': 'ChatGPT',
+    'website': 'https://openai.com',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/model_ai_prompt_views.xml',
+    ],
+    'installable': True,
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/model_ai/models/__init__.py
+++ b/model_ai/models/__init__.py
@@ -1,0 +1,1 @@
+from . import model_ai_prompt

--- a/model_ai/models/model_ai_prompt.py
+++ b/model_ai/models/model_ai_prompt.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+
+import requests
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class ModelAIPrompt(models.Model):
+    _name = 'model.ai.prompt'
+    _description = 'ChatGPT Prompt'
+
+    name = fields.Char(string='Title', required=True, default=lambda self: _('New Prompt'))
+    prompt = fields.Text(string='Prompt', required=True)
+    response = fields.Text(string='Response', readonly=True)
+    model_name = fields.Char(string='Model', default='gpt-3.5-turbo')
+    temperature = fields.Float(string='Temperature', default=0.2)
+    max_tokens = fields.Integer(string='Max Tokens', default=256)
+
+    def action_send_prompt(self):
+        for record in self:
+            record._send_prompt_to_openai()
+
+    def _send_prompt_to_openai(self):
+        self.ensure_one()
+        api_key = self.env['ir.config_parameter'].sudo().get_param('model_ai.openai_api_key')
+        if not api_key:
+            raise UserError(
+                _('Please configure the OpenAI API key in System Parameters with the key "model_ai.openai_api_key".')
+            )
+
+        payload = {
+            'model': self.model_name or 'gpt-3.5-turbo',
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': self.prompt,
+                }
+            ],
+            'temperature': self.temperature,
+            'max_tokens': self.max_tokens or 256,
+        }
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {api_key}',
+        }
+
+        try:
+            response = requests.post(
+                'https://api.openai.com/v1/chat/completions',
+                headers=headers,
+                data=json.dumps(payload),
+                timeout=60,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            _logger.exception('OpenAI API HTTP error: %s', exc)
+            raise UserError(_('OpenAI API returned an error: %s') % exc.response.text)
+        except requests.RequestException as exc:
+            _logger.exception('OpenAI API request error: %s', exc)
+            raise UserError(_('Could not reach OpenAI API: %s') % exc)
+
+        data = response.json()
+        try:
+            message = data['choices'][0]['message']['content']
+        except (KeyError, IndexError) as exc:
+            _logger.exception('Unexpected OpenAI API response: %s', data)
+            raise UserError(_('Unexpected response format from OpenAI: %s') % exc)
+
+        self.write({'response': message})
+        return True

--- a/model_ai/security/ir.model.access.csv
+++ b/model_ai/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_model_ai_prompt_user,access_model_ai_prompt_user,model_model_ai_prompt,base.group_user,1,1,1,1

--- a/model_ai/views/model_ai_prompt_views.xml
+++ b/model_ai/views/model_ai_prompt_views.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_model_ai_prompt_tree" model="ir.ui.view">
+        <field name="name">model.ai.prompt.tree</field>
+        <field name="model">model.ai.prompt</field>
+        <field name="arch" type="xml">
+            <tree string="AI Prompts">
+                <field name="name"/>
+                <field name="model_name"/>
+                <field name="temperature"/>
+                <field name="max_tokens"/>
+                <field name="response"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_model_ai_prompt_form" model="ir.ui.view">
+        <field name="name">model.ai.prompt.form</field>
+        <field name="model">model.ai.prompt</field>
+        <field name="arch" type="xml">
+            <form string="AI Prompt">
+                <header>
+                    <button name="action_send_prompt" type="object" string="Send Prompt" class="oe_highlight"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="model_name"/>
+                        <field name="temperature"/>
+                        <field name="max_tokens"/>
+                    </group>
+                    <notebook>
+                        <page string="Prompt">
+                            <field name="prompt" placeholder="Describe your request for ChatGPT here..."/>
+                        </page>
+                        <page string="Response">
+                            <field name="response" nolabel="1" readonly="1"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_model_ai_prompt" model="ir.actions.act_window">
+        <field name="name">AI Prompts</field>
+        <field name="res_model">model.ai.prompt</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first prompt and send it to ChatGPT.
+            </p>
+        </field>
+    </record>
+
+    <menuitem id="menu_model_ai_root" name="Model AI" parent="base.menu_custom" sequence="10"/>
+    <menuitem id="menu_model_ai_prompt" name="Prompts" parent="menu_model_ai_root" action="action_model_ai_prompt"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add the new `model_ai` addon for managing ChatGPT prompts and responses in Odoo 14
- implement an action that calls the OpenAI Chat Completions API and stores the reply
- expose list and form views with a menu entry and document configuration steps

## Testing
- python3 -m compileall model_ai

------
https://chatgpt.com/codex/tasks/task_e_68cacaf6ee0483259629622da9eb12a7