### PR TITLE
Add CAPA context fields to AI prompt

### DIFF
--- a/model_ai/__manifest__.py
+++ b/model_ai/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Model AI',
-    'version': '14.0.1.0.0',
+    'version': '14.0.1.1.0',
     'summary': 'Integrate ChatGPT prompts inside Odoo',
     'description': 'Send prompts to OpenAI\'s ChatGPT API and capture the responses.',
     'category': 'Productivity',

--- a/model_ai/views/model_ai_prompt_views.xml
+++ b/model_ai/views/model_ai_prompt_views.xml
@@ -6,9 +6,11 @@
         <field name="arch" type="xml">
             <tree string="AI Prompts">
                 <field name="name"/>
+                <field name="nomor_spk"/>
                 <field name="model_name"/>
                 <field name="temperature"/>
                 <field name="max_tokens"/>
+                <field name="customer_complaint"/>
                 <field name="response"/>
             </tree>
         </field>
@@ -25,6 +27,7 @@
                 <sheet>
                     <group>
                         <field name="name"/>
+                        <field name="nomor_spk"/>
                         <field name="model_name"/>
                         <field name="temperature"/>
                         <field name="max_tokens"/>
@@ -32,6 +35,7 @@
                     <notebook>
                         <page string="Prompt">
                             <field name="prompt" placeholder="Describe your request for ChatGPT here..."/>
+                            <field name="customer_complaint" placeholder="Tuliskan keluhan pelanggan..."/>
                         </page>
                         <page string="Response">
                             <field name="response" nolabel="1" readonly="1"/>


### PR DESCRIPTION
## Summary
- add nomor SPK and customer complaint fields so prompts can capture CAPA context
- merge the entered data into the ChatGPT request payload with a CAPA instruction
- expose the new context fields in the tree and form views and bump the module version

## Testing
- python3 -m compileall model_ai

------
https://chatgpt.com/codex/tasks/task_e_68cad10bcc64832586e5d8132a3655cc