### PR TITLE
Add fishbone analysis image generation

### DIFF
--- a/model_ai/views/model_ai_prompt_views.xml
+++ b/model_ai/views/model_ai_prompt_views.xml
@@ -40,6 +40,9 @@
                         <page string="Response">
                             <field name="response" nolabel="1" readonly="1"/>
                         </page>
+                        <page string="Fishbone Analysis">
+                            <field name="fishbone_analysis_image" widget="image" class="oe_avatar"/>
+                        </page>
                     </notebook>
                 </sheet>
             </form>


### PR DESCRIPTION
## Summary
- add a binary field to store fishbone analysis images generated from ChatGPT responses
- call the OpenAI images API after receiving the text response to request a fishbone diagram and store it when available
- surface the generated fishbone analysis image on a dedicated notebook page in the form view

## Testing
- python3 -m compileall model_ai

------
https://chatgpt.com/codex/tasks/task_e_68cad3e248048325ab4a68a4f635172c