### PR TITLE
Adjust response structure instructions

### DIFF
--- a/model_ai/models/model_ai_prompt.py
+++ b/model_ai/models/model_ai_prompt.py
@@ -89,7 +89,16 @@ class ModelAIPrompt(models.Model):
     def _compose_prompt_content(self):
         self.ensure_one()
 
-        sections = [_('Buatkan analisis dan rencana tindakan CAPA berdasarkan data berikut.')]
+        sections = [
+            _('Buatkan analisis dan rencana tindakan CAPA berdasarkan data berikut.'),
+            _(
+                'Susun respons dengan urutan bagian sebagai berikut:\n'
+                '1. Masalah dari Pelanggan (ringkas kembali inti keluhan).\n'
+                '2. Analisa Masalah (jelaskan analisis akar penyebab secara singkat dan jelas).\n'
+                '3. Fishbone Analysis (uraikan visualisasi atau rangkuman diagram sebelum bagian lain).\n'
+                'Lanjutkan dengan bagian-bagian pendukung lain seperti rencana tindakan CAPA dan indikator keberhasilan.'
+            ),
+        ]
         if self.prompt:
             sections.append(self.prompt.strip())
         context_lines = []


### PR DESCRIPTION
## Summary
- clarify the base instruction for generated responses to include a dedicated problem analysis section before the fishbone analysis
- ensure both sections are requested immediately after the customer problem and that the rest of the CAPA guidance follows afterward

## Testing
- python3 -m compileall model_ai

------
https://chatgpt.com/codex/tasks/task_e_68cb3a6729b08325a2b1c3be31a48beb