### PR TITLE
Add structured response fields for ChatGPT analysis

### DIFF
--- a/model_ai/views/model_ai_prompt_views.xml
+++ b/model_ai/views/model_ai_prompt_views.xml
@@ -11,6 +11,10 @@
                 <field name="temperature"/>
                 <field name="max_tokens"/>
                 <field name="customer_complaint"/>
+                <field name="response_problem_summary"/>
+                <field name="response_root_cause"/>
+                <field name="response_fishbone_summary"/>
+                <field name="response_supporting_plan"/>
                 <field name="response"/>
             </tree>
         </field>
@@ -38,6 +42,15 @@
                             <field name="customer_complaint" placeholder="Tuliskan keluhan pelanggan..."/>
                         </page>
                         <page string="Response">
+                            <group>
+                                <field name="response_problem_summary" readonly="1"/>
+                                <field name="response_root_cause" readonly="1"/>
+                            </group>
+                            <group>
+                                <field name="response_fishbone_summary" readonly="1"/>
+                                <field name="response_supporting_plan" readonly="1"/>
+                            </group>
+                            <separator string="Raw Response"/>
                             <field name="response" nolabel="1" readonly="1"/>
                         </page>
                         <page string="Fishbone Analysis">


### PR DESCRIPTION
## Summary
- add dedicated fields to store each requested section of the ChatGPT response
- parse the generated response to populate the new section fields automatically
- surface the structured sections on the prompt tree and form views alongside the raw reply

## Testing
- python3 -m compileall model_ai

------
https://chatgpt.com/codex/tasks/task_e_68cb3fe50de883258e464c730e928764