### PR TITLE
Add SPK history field and include it in prompt context

### DIFF
--- a/model_ai/models/model_ai_prompt.py
+++ b/model_ai/models/model_ai_prompt.py
@@ -18,6 +18,7 @@ class ModelAIPrompt(models.Model):
     name = fields.Char(string='Title', required=True, default=lambda self: _('New Prompt'))
     prompt = fields.Text(string='Prompt', required=True)
     nomor_spk = fields.Char(string='Nomor SPK')
+    history_spk = fields.Text(string='History SPK')
     customer_complaint = fields.Text(string='Keluhan Pelanggan')
     response = fields.Text(string='Response', readonly=True)
     response_problem_summary = fields.Text(string='Masalah dari Pelanggan', readonly=True)
@@ -109,9 +110,18 @@ class ModelAIPrompt(models.Model):
         ]
         if self.prompt:
             sections.append(self.prompt.strip())
+        if self.history_spk and self.history_spk.strip():
+            sections.append(
+                _(
+                    'Gunakan riwayat SPK berikut sebagai referensi utama ketika mencari akar penyebab masalah:'
+                )
+            )
+            sections.append(self.history_spk.strip())
         context_lines = []
         if self.nomor_spk and self.nomor_spk.strip():
             context_lines.append(_('Nomor SPK: %s') % self.nomor_spk.strip())
+        if self.history_spk and self.history_spk.strip():
+            context_lines.append(_('History SPK: %s') % self.history_spk.strip())
         if self.customer_complaint and self.customer_complaint.strip():
             context_lines.append(_('Keluhan Pelanggan: %s') % self.customer_complaint.strip())
 

--- a/model_ai/views/model_ai_prompt_views.xml
+++ b/model_ai/views/model_ai_prompt_views.xml
@@ -39,6 +39,7 @@
                     <notebook>
                         <page string="Prompt">
                             <field name="prompt" placeholder="Describe your request for ChatGPT here..."/>
+                            <field name="history_spk" placeholder="Ringkasan riwayat SPK terkait..."/>
                             <field name="customer_complaint" placeholder="Tuliskan keluhan pelanggan..."/>
                         </page>
                         <page string="Response">


### PR DESCRIPTION
## Summary
- add a History SPK field to the AI prompt model and form view
- include the SPK history text as contextual guidance for root cause analysis in generated prompts

## Testing
- python3 -m compileall model_ai

------
https://chatgpt.com/codex/tasks/task_e_68cb526f9f48832581843118876089f9