### PR TITLE
Fix telegram bot token env var lookup

### DIFF
--- a/parkir_mobil/telegram_bot.py
+++ b/parkir_mobil/telegram_bot.py
@@ -101,7 +101,7 @@ async def parkir_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 def main() -> None:
-    token = _env("8498543613:AAERSSpz5kd__pl_Xnz2JmgCxg3uE1Nqzu8")
+    token = _env("TELEGRAM_BOT_TOKEN")
     application = ApplicationBuilder().token(token).build()
 
     application.add_handler(CommandHandler("help", help_command))


### PR DESCRIPTION
### Motivation
- The bot previously attempted to read the actual token string as an environment variable name, causing a `RuntimeError` on startup. 
- The code should read the Telegram token from the `TELEGRAM_BOT_TOKEN` environment variable as documented in the file header. 

### Description
- Replaced the incorrect call `token = _env("8498543613:AAERSSpz5kd__pl_Xnz2JmgCxg3uE1Nqzu8")` with `token = _env("TELEGRAM_BOT_TOKEN")` in `parkir_mobil/telegram_bot.py` to look up the proper env var. 
- No other behavioral changes were made; the bot still registers the same command handlers and runs polling. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69631f84fd888325870758e194c66c38)