### PR TITLE
Handle polling conflicts and add error logging to Telegram bot

### DIFF
--- a/parkir_mobil/telegram_bot.py
+++ b/parkir_mobil/telegram_bot.py
@@ -13,12 +13,15 @@ Example:
 /parkir 2024-05-15 B1234CD 08:30 11:15
 """
 
+import logging
 import os
 from datetime import datetime
 from xmlrpc import client as xmlrpc_client
 
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+logger = logging.getLogger(__name__)
 
 
 def _env(name: str) -> str:
@@ -100,14 +103,20 @@ async def parkir_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     )
 
 
+async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.exception("Unhandled exception in bot update processing", exc_info=context.error)
+
+
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     token = _env("TELEGRAM_BOT_TOKEN")
     application = ApplicationBuilder().token(token).build()
 
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("parkir", parkir_command))
+    application.add_error_handler(error_handler)
 
-    application.run_polling()
+    application.run_polling(drop_pending_updates=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent unhandled-exception warnings such as "No error handlers are registered" by adding a global error handler.
- Avoid `telegram.error.Conflict` caused by stale `getUpdates` sessions by dropping pending updates on startup.
- Ensure exceptions during update processing are captured in logs for easier debugging. 
- Improve runtime stability when multiple bot instances or previous sessions exist.

### Description
- Import `logging` and create a module-level `logger` with `logger = logging.getLogger(__name__)`.
- Add an `error_handler(update, context)` that records exceptions using `logger.exception` with `exc_info=context.error`.
- Configure basic logging via `logging.basicConfig(level=logging.INFO)` and register the handler with `application.add_error_handler(error_handler)`.
- Start the bot with `application.run_polling(drop_pending_updates=True)` to drop pending updates and avoid polling conflicts.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696322a7cfd4832582a457c0578ebc7e)